### PR TITLE
Create new <Time> component, remove date-fns from most other components

### DIFF
--- a/src/atoms/Time/README.md
+++ b/src/atoms/Time/README.md
@@ -1,0 +1,23 @@
+# Time
+
+The `<Time>` component renders a basic `<time>` html element with a `datetime` attribute and formats the time as needed for visual display. The intend is to provide a valid machine-readable `dateTime` prop which will be uses as the `datetime` attribute but formatted inside the element in a human-readable format.
+
+For example, as a basic usage, `<Time dateTime="2019-07-18T04:00:00-05:00" />` would produce the HTML: `<time datetime="2019-07-18T04:00:00-05:00">July 18, 2019</time>`
+
+## Properties
+
+### dateTime\*
+
+Required. Accepts a string which should ideally be formatted to ISO-8601 standard (e.g. `2019-07-18T04:00:00-05:00`), although the date-fns library may also be able to parse other formats.
+
+### type
+
+Accepts either `distance` or `timestamp`. Default value is `timestamp`. Determines whether to format as a timestamp (like `July 18, 2019`) or the time "distance" (the amout of time "ago", e.g. `10 minutes`). Any templating for the `distance` type (adding the word "ago", for example) is outside the scope of this component and should be done in your app where the Time component is invoked.
+
+### formatString
+
+Accepts a string. The format to use for the `timestamp` type, using the tokens described in [date-fns format](https://date-fns.org/v1.30.1/docs/format). This defaults to the format `MMMM D, YYYY`, producing a date output like `July 18, 2019`. This prop has no effect if prop `type="distance"`.
+
+### elementClass
+
+Accepts a string. Adds a `class` property to the resulting html for styling usage.

--- a/src/atoms/Time/Time.js
+++ b/src/atoms/Time/Time.js
@@ -8,7 +8,7 @@ const Time = (props) => {
       <time
         className={props.elementClass && props.elementClass}
         dateTime={props.dateTime}
-        title={format(props.dateTime, 'MMMM D, YYYY H:mm aa')}
+        title={format(props.dateTime, 'MMMM D, YYYY h:mm aa')}
       >
         {distanceInWordsToNow(props.dateTime)}
       </time>

--- a/src/atoms/Time/Time.js
+++ b/src/atoms/Time/Time.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { format, distanceInWordsToNow } from 'date-fns';
+
+const Time = (props) => {
+  if (props.type === 'distance') {
+    return (
+      <time
+        className={props.elementClass && props.elementClass}
+        dateTime={props.dateTime}
+        title={format(props.dateTime, 'MMMM D, YYYY H:mm aa')}
+      >
+        {distanceInWordsToNow(props.dateTime)}
+      </time>
+    );
+  } else {
+    return (
+      <time
+        className={props.elementClass && props.elementClass}
+        dateTime={props.dateTime}
+      >
+        {format(props.dateTime, props.formatString)}
+      </time>
+    );
+  }
+};
+
+Time.defaultProps = {
+  type: 'timestamp',
+  formatString: 'MMMM D, YYYY'
+};
+
+Time.propTypes = {
+  dateTime: PropTypes.string.isRequired,
+  elementClass: PropTypes.string,
+  formatString: PropTypes.string,
+  type: PropTypes.oneOf(['timestamp', 'distance'])
+};
+
+export default Time;

--- a/src/atoms/Time/Time.story.js
+++ b/src/atoms/Time/Time.story.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
+import Time from './Time';
+import { withReadme } from 'storybook-readme';
+import readme from './README.md';
+
+const stories = storiesOf('Atoms/Time', module);
+
+stories.addDecorator(withKnobs()).addDecorator(withReadme([readme]));
+
+stories.add('Time All Props', () => {
+  return (
+    <Time
+      dateTime={text('DateTime', '2019-07-18T04:00:00-05:00')}
+      type={select('Type', ['timestamp', 'distance'], 'timestamp')}
+      formatString={text('Format String', 'MMMM DD, YYYY')}
+      elementClass={text('elementClass', '')}
+    />
+  );
+});

--- a/src/atoms/Time/tests/Time.test.js
+++ b/src/atoms/Time/tests/Time.test.js
@@ -23,8 +23,15 @@ describe('Time', () => {
   });
 
   test('uses "time ago" format when prop type="distance"', () => {
+    const titleFormat = 'MMMM D, YYYY h:mm aa';
+    // Calculate dateTimes based on current test runner's time
     const dateFiveDaysAgo = format(subDays(new Date(), 5)).toString();
+    const formattedTimeFiveDaysAgo = format(dateFiveDaysAgo, titleFormat);
     const dateTwelveMinutesAgo = format(subMinutes(new Date(), 12)).toString();
+    const formattedTimeTwelveMinutesAgo = format(
+      dateTwelveMinutesAgo,
+      titleFormat
+    );
 
     const { getByText } = render(
       <>
@@ -34,10 +41,16 @@ describe('Time', () => {
     );
     const fiveDaysEl = getByText('5 days');
     const twelveMinsEl = getByText('12 minutes');
+
     expect(fiveDaysEl.innerHTML).toBe('5 days');
     expect(fiveDaysEl.getAttribute('datetime')).toBe(dateFiveDaysAgo);
+    expect(fiveDaysEl.getAttribute('title')).toBe(formattedTimeFiveDaysAgo);
+
     expect(twelveMinsEl.innerHTML).toBe('12 minutes');
     expect(twelveMinsEl.getAttribute('datetime')).toBe(dateTwelveMinutesAgo);
+    expect(twelveMinsEl.getAttribute('title')).toBe(
+      formattedTimeTwelveMinutesAgo
+    );
   });
 
   test('formats the timestamp according to the format prop', () => {

--- a/src/atoms/Time/tests/Time.test.js
+++ b/src/atoms/Time/tests/Time.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import Time from '../Time';
+import { format, subDays, subMinutes } from 'date-fns';
+
+// automatically unmount and cleanup DOM after the test is finished.
+afterEach(cleanup);
+
+describe('Time', () => {
+  test('renders a <time> element with the default config', () => {
+    const { getByText } = render(<Time dateTime="2019-07-18T04:00:00-05:00" />);
+    const timeEl = getByText('July 18, 2019');
+    expect(timeEl.tagName).toBe('TIME');
+    expect(timeEl.innerHTML).toBe('July 18, 2019');
+    expect(timeEl.getAttribute('datetime')).toBe('2019-07-18T04:00:00-05:00');
+    expect(timeEl.className).toBe('');
+  });
+
+  test('throws an error when a isRequired value is missing', () => {
+    expect(() => {
+      render(<Time />);
+    }).toThrow();
+  });
+
+  test('uses "time ago" format when prop type="distance"', () => {
+    const dateFiveDaysAgo = format(subDays(new Date(), 5)).toString();
+    const dateTwelveMinutesAgo = format(subMinutes(new Date(), 12)).toString();
+
+    const { getByText } = render(
+      <>
+        <Time dateTime={dateFiveDaysAgo} type="distance" />
+        <Time dateTime={dateTwelveMinutesAgo} type="distance" />
+      </>
+    );
+    const fiveDaysEl = getByText('5 days');
+    const twelveMinsEl = getByText('12 minutes');
+    expect(fiveDaysEl.innerHTML).toBe('5 days');
+    expect(fiveDaysEl.getAttribute('datetime')).toBe(dateFiveDaysAgo);
+    expect(twelveMinsEl.innerHTML).toBe('12 minutes');
+    expect(twelveMinsEl.getAttribute('datetime')).toBe(dateTwelveMinutesAgo);
+  });
+
+  test('formats the timestamp according to the format prop', () => {
+    const { getByText } = render(
+      <Time dateTime="2019-07-18T04:00:00-05:00" formatString="MM-DD-YYYY" />
+    );
+    const timeEl = getByText('07-18-2019');
+    expect(timeEl.innerHTML).toBe('07-18-2019');
+    expect(timeEl.getAttribute('datetime')).toBe('2019-07-18T04:00:00-05:00');
+  });
+
+  test('adds a class to the element when an `elementClass` prop is passed in', () => {
+    const { getByText } = render(
+      <Time
+        dateTime="2019-07-18T04:00:00-05:00"
+        elementClass="custom classes"
+      />
+    );
+    expect(getByText('July 18, 2019').className).toBe('custom classes');
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import Heading from './atoms/Heading/Heading';
 import Loading from './atoms/Loading/Loading';
 import Pagination from './atoms/Pagination/Pagination';
 import TagLink from './atoms/TagLink/TagLink';
+import Time from './atoms/Time/Time';
 
 // import AudioPlayer from './molecules/AudioPlayer/AudioPlayer';
 import Body from './molecules/Body/Body';
@@ -21,6 +22,7 @@ export {
   Loading,
   Pagination,
   TagLink,
+  Time,
   // AudioPlayer,
   Body,
   Content,

--- a/src/molecules/Content/Content.js
+++ b/src/molecules/Content/Content.js
@@ -56,7 +56,7 @@ Content.propTypes = {
     })
   ),
   headingLevel: PropTypes.number,
-  publishDate: PropTypes.string,
+  publishDate: PropTypes.node,
   subtitle: PropTypes.string,
   bodyHtml: PropTypes.string,
   image: PropTypes.object,

--- a/src/molecules/Content/ContentHeader.js
+++ b/src/molecules/Content/ContentHeader.js
@@ -46,7 +46,7 @@ const ContentHeader = ({
           </div>
         )}
 
-        {publishDate && publishDate}
+        {publishDate}
       </div>
     </header>
   );

--- a/src/molecules/Content/ContentHeader.js
+++ b/src/molecules/Content/ContentHeader.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Link from 'next/link';
 import Heading from '../../atoms/Heading/Heading';
 import TagLink from '../../atoms/TagLink/TagLink';
-import { format } from 'date-fns';
 
 const ContentHeader = ({
   title,
@@ -47,11 +46,7 @@ const ContentHeader = ({
           </div>
         )}
 
-        {publishDate && (
-          <time dateTime={publishDate}>
-            {format(publishDate, 'MMMM D, YYYY')}
-          </time>
-        )}
+        {publishDate && publishDate}
       </div>
     </header>
   );
@@ -65,7 +60,7 @@ ContentHeader.propTypes = {
     })
   ),
   headingLevel: PropTypes.number,
-  publishDate: PropTypes.string,
+  publishDate: PropTypes.node,
   subtitle: PropTypes.string,
   tag: PropTypes.shape({
     href: PropTypes.string,

--- a/src/molecules/Content/README.md
+++ b/src/molecules/Content/README.md
@@ -36,7 +36,7 @@ Accepts a URL string. Turns the credit on the `<Figure />` into a link.
 
 ### publishDate
 
-Accepts an unformatted date from the CMS endpoint. Returns a date formatted 'MMMM DD, YYYY' by [date-fns](https://date-fns.org/)
+Accepts a node. Ideally this should include a `<time>` element. A properly formatted `<time>` element can be created using Titan's `Time` component as a helper.
 
 ### subtitle
 
@@ -53,6 +53,6 @@ Accepts an object of the shape:
 }
 ```
 
-### title*
+### title\*
 
 Accepts a string. Becomes the title of the page.

--- a/src/molecules/Content/tests/ContentHeader.test.js
+++ b/src/molecules/Content/tests/ContentHeader.test.js
@@ -13,7 +13,7 @@ const testProps = {
     { name: 'Bill', href: '/bio/bill' }
   ],
   headingLevel: 1,
-  publishDate: 'Jan 12, 2018',
+  publishDate: 'January 12, 2018',
   subtitle: 'this is a subtitle',
   tag: { to: '/taglink', tagName: 'tag' }
 };
@@ -62,7 +62,7 @@ describe('ContentHeader component', () => {
     const { container } = render(<ContentHeader title={testProps.title} />);
     // Verify that the publish date html isn't rendered
     // expect(container.find('time').exists()).toBe(false);
-    expect(container.getElementsByTagName('date').length).toBe(0);
+    expect(container.getElementsByTagName('time').length).toBe(0);
   });
 
   test('renders the Heading component with appropriate heading level', () => {

--- a/src/molecules/Event/Event.js
+++ b/src/molecules/Event/Event.js
@@ -72,7 +72,7 @@ Event.propTypes = {
       description: PropTypes.string
     })
   ),
-  publishDate: PropTypes.string,
+  publishDate: PropTypes.node,
   tag: PropTypes.shape({
     tagName: PropTypes.string,
     to: PropTypes.string

--- a/src/molecules/Event/EventDates.js
+++ b/src/molecules/Event/EventDates.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
+import Time from '../../atoms/Time/Time';
 
 const EventDates = ({ eventDates }) => {
   return (
@@ -10,9 +10,7 @@ const EventDates = ({ eventDates }) => {
         {eventDates.map((event, index) => {
           return (
             <li key={index}>
-              <time dateTime={event.date}>
-                {format(event.date, 'MMMM D, YYYY')}
-              </time>
+              <Time dateTime={event.date} formatString="MMMM D, YYYY" />
             </li>
           );
         })}

--- a/src/molecules/Event/EventHeader.js
+++ b/src/molecules/Event/EventHeader.js
@@ -24,9 +24,7 @@ const EventHeader = ({ title, subtitle, tag, headingLevel, publishDate }) => {
         </p>
       )}
 
-      <div className="event_meta">
-        {publishDate && <time dateTime={publishDate}>{publishDate}</time>}
-      </div>
+      {publishDate && <div className="event_meta">{publishDate}</div>}
     </header>
   );
 };
@@ -34,7 +32,7 @@ const EventHeader = ({ title, subtitle, tag, headingLevel, publishDate }) => {
 EventHeader.propTypes = {
   subtitle: PropTypes.string,
   headingLevel: PropTypes.number,
-  publishDate: PropTypes.string,
+  publishDate: PropTypes.node,
   tag: PropTypes.shape({
     href: PropTypes.string,
     tagName: PropTypes.string

--- a/src/molecules/Hero/Hero.js
+++ b/src/molecules/Hero/Hero.js
@@ -62,7 +62,7 @@ Hero.propTypes = {
   contributorsText: PropTypes.string,
   href: PropTypes.string,
   image: PropTypes.object.isRequired,
-  publishDate: PropTypes.string,
+  publishDate: PropTypes.node,
   subHead: PropTypes.string,
   tag: PropTypes.object
 };

--- a/src/molecules/Hero/HeroInner.js
+++ b/src/molecules/Hero/HeroInner.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
 
 const HeroInner = ({ image, publishDate, button }) => (
   <>
@@ -10,13 +9,7 @@ const HeroInner = ({ image, publishDate, button }) => (
         <img alt={image.alt} src={image.src} />
       </picture>
     </figure>
-    <div className="item_content_meta">
-      {publishDate && (
-        <time dateTime={publishDate}>
-          {format(publishDate, 'MMMM D, YYYY')}
-        </time>
-      )}
-    </div>
+    {publishDate && <div className="item_content_meta">{publishDate}</div>}
 
     {/* TODO: Need to disscuss this more to determine the direction of
             what we want to do about the button */}

--- a/src/molecules/Hero/README.md
+++ b/src/molecules/Hero/README.md
@@ -1,7 +1,6 @@
 # Hero
 
-A `<Hero />` component is used to highlight a particular story on a collection, or a particular aspect of a page. What it can be or do can change a lot depending on the project. It has a single subcomponent, `<Inner />`. The version we have here is a pretty simple and typical, but depending on whether it needs to have a play button or some other interactivity, this component could grow a lot. 
-
+A `<Hero />` component is used to highlight a particular story on a collection, or a particular aspect of a page. What it can be or do can change a lot depending on the project. It has a single subcomponent, `<Inner />`. The version we have here is a pretty simple and typical, but depending on whether it needs to have a play button or some other interactivity, this component could grow a lot.
 
 ## Properties
 
@@ -17,13 +16,13 @@ Accepts a string. Displays the contributors to this article/item, if any.
 
 Accepts a URL string. If this is provided, the `<Inner />` component of the hero will be wrapped in a `<Link />`.
 
-### image*
+### image\*
 
 Accepts a data object of any shape.
 
 ### publishDate
 
-Accepts a date string. Is parsed by `date-fns`  and, if valid, is reformatted to be 'MMMM D, YYYY' (for example, September 2, 2019).
+Accepts a node. Ideally this should include a `<time>` element. A properly formatted `<time>` element can be created using Titan's `Time` component as a helper.
 
 ### subHead
 
@@ -33,6 +32,6 @@ Accepts a string, which becomes this Hero's "subtitle", if applicable.
 
 Accepts an object of any shape.
 
-### title*
+### title\*
 
 Accepts a string, which becomes this Hero's "title".

--- a/src/molecules/Teaser/README.md
+++ b/src/molecules/Teaser/README.md
@@ -32,7 +32,7 @@ Accepts an HTML object, or alternatively a React component. It is recommended th
 
 ### publishDate
 
-Accepts a date string. If successfully parsed by `date-fns`, this date is shown on the teaser.
+Accepts a node. Ideally this should include a `<time>` element. A properly formatted `<time>` element can be created using Titan's `Time` component as a helper.
 
 ### tag
 

--- a/src/molecules/Teaser/Teaser.js
+++ b/src/molecules/Teaser/Teaser.js
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import Heading from '../../atoms/Heading/Heading';
 import TagLink from '../../atoms/TagLink/TagLink';
 import { toSentence } from '../../utils/utils';
-import { format } from 'date-fns';
 
 const Teaser = ({
   title,
@@ -49,11 +48,7 @@ const Teaser = ({
               <Heading level={headingLevel}>{title}</Heading>
             </div>
             <div className="teaser_meta">
-              {publishDate && (
-                <time className="teaser_time" dateTime={publishDate}>
-                  {format(publishDate, 'MMMM D, YYYY')}
-                </time>
-              )}
+              {publishDate && publishDate}
               {contributors && (
                 <div className="teaser_contributors">
                   By {toSentence(contributors)}
@@ -79,7 +74,7 @@ Teaser.propTypes = {
   href: PropTypes.string.isRequired,
   as: PropTypes.string,
   image: PropTypes.object,
-  publishDate: PropTypes.string,
+  publishDate: PropTypes.node,
   tag: PropTypes.shape({
     to: PropTypes.string.isRequired,
     tagName: PropTypes.string.isRequired

--- a/src/molecules/Teaser/Teaser.js
+++ b/src/molecules/Teaser/Teaser.js
@@ -48,7 +48,8 @@ const Teaser = ({
               <Heading level={headingLevel}>{title}</Heading>
             </div>
             <div className="teaser_meta">
-              {publishDate && publishDate}
+              {publishDate}
+
               {contributors && (
                 <div className="teaser_contributors">
                   By {toSentence(contributors)}

--- a/src/molecules/Teaser/tests/Teaser.test.js
+++ b/src/molecules/Teaser/tests/Teaser.test.js
@@ -3,13 +3,15 @@ import { render, cleanup } from '@testing-library/react';
 import { image } from '../../../testdata/image';
 import { Image } from 'apm-mimas';
 import Teaser from '../Teaser';
+import Time from '../../../atoms/Time/Time';
 
 afterEach(cleanup);
 
 const href = '/the/url/path';
 const title = 'This Here Is the Title';
-const publishDate = '2019-02-26T11:48:40+00:00';
-const prettyDate = 'February 26, 2019';
+const dateTime = '2019-02-26T11:48:40+00:00';
+const publishDate = <Time dateTime={dateTime} formatString="MMM DD, YYYY" />;
+const prettyDate = 'Feb 26, 2019';
 const contributors = ['Opie Schmuck', 'Opiette Schmuck'];
 const contributorsText = 'By Opie Schmuck and Opiette Schmuck';
 const description = 'This here is the description.';
@@ -79,9 +81,7 @@ test('Date and time are rendered correctly if publishDate prop has been provided
   );
   const timeEle = container.querySelector('time');
 
-  expect(timeEle.attributes.getNamedItem('dateTime').value).toEqual(
-    publishDate
-  );
+  expect(timeEle.attributes.getNamedItem('dateTime').value).toEqual(dateTime);
   expect(timeEle.textContent).toEqual(prettyDate);
 });
 


### PR DESCRIPTION
The intent of this is to be able to pass in anything as the `pubDate` prop for components that need one, so that the pubdate can be formatted however we need. In addition to this I created a `<Time>` component to handle formatting dates/times more easily.

This means that when using, for example, a Teaser component, we should pass in the `<Time>` component as the pubDate prop, like:

```
<Teaser pubDate={<Time dateTime={story.pubdate} />} />
```