### PR TITLE
modify video support with work around react error on video muted attr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apmg/titan",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/APMG/apm-titan.git"

--- a/src/molecules/Teaser/Teaser.js
+++ b/src/molecules/Teaser/Teaser.js
@@ -42,16 +42,17 @@ const Teaser = ({
 
       <Link href={href} as={as} className="teaser_link">
         <div className="teaser_image">{image}</div>
+
         {video && (
           <div className="teaser_video">
             <figure className="figure">
-              <video id={video?.credit?.name} autoPlay="true" muted="true">
+              <video id={video.credit.name} autoPlay={true} muted={true}>
                 <source src={video.url} type="video/mp4" />
                 Your browser does not support HTML5 video.
               </video>
               <figcaption className="figure_caption">
-                <div className="figure_caption_content">{video?.caption}</div>
-                <span className="figure_credit">{video?.credit?.name}</span>
+                <div className="figure_caption_content">{video.caption}</div>
+                <span className="figure_credit">{video.credit.name}</span>
               </figcaption>
             </figure>
           </div>

--- a/src/molecules/Teaser/__test__/Teaser.test.js
+++ b/src/molecules/Teaser/__test__/Teaser.test.js
@@ -7,12 +7,34 @@ import Time from '../../../atoms/Time/Time';
 
 afterEach(cleanup);
 
+const renderIgnoringUnstableFlushDiscreteUpdates = (component) => {
+  // tslint:disable: no-console
+  const originalError = console.error;
+  const error = jest.fn();
+  console.error = error;
+  const result = render(component);
+  expect(error).toHaveBeenCalledTimes(1);
+  expect(error).toHaveBeenCalledWith(
+    'Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering.%s',
+    expect.any(String)
+  );
+  console.error = originalError;
+  // tslint:enable: no-console
+  return result;
+};
+
 const defaultProps = {
   href: '/the/url/path',
   title: 'This Here Is the Title',
   contributors: ['Opie Schmuck', 'Opiette Schmuck'],
   description: 'This here is the description.',
-  dateTime: '2019-02-26T11:48:40+00:00'
+  dateTime: '2019-02-26T11:48:40+00:00',
+  video: {
+    url: 'https://mpr.apmcdn.org/video/apmreports/chicagoclean.mp4',
+    caption: 'this is a video caption',
+    background: 'true',
+    credit: { name: 'credit name' }
+  }
 };
 
 const expected = {
@@ -128,6 +150,24 @@ test('The following optional sections are not rendered when their corresponding 
   );
   expect(container.querySelectorAll('.tag')).toHaveLength(0);
   expect(container.querySelectorAll('image')).toHaveLength(0);
+});
+
+test('Renders video object', () => {
+  const { container, getByText } = renderIgnoringUnstableFlushDiscreteUpdates(
+    <Teaser
+      headingLevel={3}
+      href={defaultProps.href}
+      title={defaultProps.title}
+      video={defaultProps.video}
+    />
+  );
+
+  const videoNode = getByText('this is a video caption');
+
+  expect(videoNode.textContent).toBe('this is a video caption');
+  expect(container.querySelectorAll('figure_caption')).toHaveLength(0);
+  expect(container.querySelectorAll('figure_caption_content')).toHaveLength(0);
+  expect(container.querySelectorAll('figure_credit')).toHaveLength(0);
 });
 
 test('Throws an error when required value is missing', () => {

--- a/src/molecules/Teaser/__testdata__/teaser.js
+++ b/src/molecules/Teaser/__testdata__/teaser.js
@@ -11,7 +11,7 @@ export const teaser = {
       caption: 'this is a video caption',
       background: 'true',
       credit: { name: 'credit name' }
-    }
+    },
     __typename: 'PrimaryVisual'
   },
   audio: [

--- a/src/molecules/Teaser/__testdata__/teaser.js
+++ b/src/molecules/Teaser/__testdata__/teaser.js
@@ -6,6 +6,12 @@ export const teaser = {
   canonicalSlug: '2018/10/17/update-on-episode-51-nebach',
   primaryVisuals: {
     lead: null,
+    video: {
+      url: 'https://mpr.apmcdn.org/video/apmreports/chicagoclean.mp4',
+      caption: 'this is a video caption',
+      background: 'true',
+      credit: { name: 'credit name' }
+    }
     __typename: 'PrimaryVisual'
   },
   audio: [


### PR DESCRIPTION
Rendering video html throws a console error: "Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering." The problem is that setting the muted property on a HTMLMediaElement leads to an event being fired, which in turn leads to flushDiscreteUpdatesIfNeeded. And this has been Verified by Kentcdodds that this is an issue not with React Testing Library, but with React. There's no definite answer, however there's a workaround "renderIgnoringUnstableFlushDiscreteUpdates()". 

Source: https://github.com/testing-library/react-testing-library/issues/470

It's also unclear if this was relevant to my original ticket of PrimaryVisuals is undefined, but this error needed to be fixed. 
https://redmine.publicradio.org/issues/43815
