### PR TITLE
Pagination: Make page 1 the plan URL rather than end with /1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "apm-html5-player": "^0.4.1",
     "apm-mimas": "^0.1.9",
     "dayjs": "^1.10.7",
-    "react-dom": "^18.2",
+    "react-dom": "^18.2.0",
     "uuid": "^7.0.2"
   },
   "peerDependencies": {
     "classnames": "^2.2.6",
     "next": "^13.0",
     "prop-types": "^15.7.2",
-    "react": "^18.2"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",
@@ -60,8 +60,8 @@
     "path": "^0.12.7",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "react": "^18.2",
-    "react-is": "^18.2",
+    "react": "^18.2.0",
+    "react-is": "^18.2.0",
     "rollup": "^1.0.0",
     "rollup-plugin-babel": "^4.3.3",
     "sass": "^1.63.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apmg/titan",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/APMG/apm-titan.git"

--- a/src/atoms/Pagination/Pagination.js
+++ b/src/atoms/Pagination/Pagination.js
@@ -92,7 +92,7 @@ const Pagination = ({
   };
 
   const currentNumOrFirstNum = middleSymbol
-    ? `${asPrefix}/${currentPage}`
+    ? `${asPrefix}${currentPage === 1 ? '' : `/${currentPage}`}`
     : `${asPrefix}`;
 
   return (
@@ -145,7 +145,7 @@ const Pagination = ({
               <li key={uuidv4()} className={pageClasses}>
                 <Link
                   href={`/${hrefPrefix}`}
-                  as={`/${asPrefix}/${value}`}
+                  as={`/${asPrefix}${value === 1 ? '' : `/${value}`}`}
                   className={linkClasses}
                 >
                   {value}

--- a/src/atoms/Pagination/Pagination.js
+++ b/src/atoms/Pagination/Pagination.js
@@ -93,7 +93,7 @@ const Pagination = ({
 
   const currentNumOrFirstNum = middleSymbol
     ? `${asPrefix}/${currentPage}`
-    : `${asPrefix}/1`;
+    : `${asPrefix}`;
 
   return (
     <nav data-testid="pagination-test" className={classes}>
@@ -118,8 +118,7 @@ const Pagination = ({
         {currentPage > 1 && (
           <li className="pagination_page pagination_page-prev">
             <Link
-              href={`/${hrefPrefix}`}
-              as={`/${asPrefix}/${prevIndex(currentPage)}`}
+              href={`/${asPrefix}/${prevIndex(currentPage)}`}
               className={prevLinkClasses}
             >
               {prevSymbol}

--- a/src/atoms/Pagination/__tests__/Pagination.test.js
+++ b/src/atoms/Pagination/__tests__/Pagination.test.js
@@ -56,7 +56,7 @@ describe('Small Pagination', () => {
     );
 
     expect(container.querySelectorAll('.pagination_link')).toHaveLength(2);
-    expect(getByText('1').href).toBe('http://localhost/episodes/1');
+    expect(getByText('1').href).toBe('http://localhost/episodes');
     expect(getByText('〉').href).toBe('http://localhost/episodes/2');
   });
 
@@ -97,7 +97,7 @@ describe('Medium Pagination', () => {
     );
 
     expect(container.querySelectorAll('.pagination_link')).toHaveLength(3);
-    expect(getByText('1').href).toBe('http://localhost/episodes/1');
+    expect(getByText('1').href).toBe('http://localhost/episodes');
     expect(getByText('2').href).toBe('http://localhost/episodes/2');
     expect(getByText('〉').href).toBe('http://localhost/episodes/2');
   });
@@ -141,7 +141,7 @@ describe('Large Pagination', () => {
     );
 
     expect(container.querySelectorAll('.pagination_link')).toHaveLength(6);
-    expect(getByText('1').href).toBe('http://localhost/episodes/1');
+    expect(getByText('1').href).toBe('http://localhost/episodes');
     expect(getByText('2').href).toBe('http://localhost/episodes/2');
     expect(getByText('3').href).toBe('http://localhost/episodes/3');
     expect(getByText('〉').href).toBe('http://localhost/episodes/2');
@@ -163,7 +163,7 @@ describe('Large Pagination', () => {
     );
 
     expect(container.querySelectorAll('.pagination_link')).toHaveLength(9);
-    expect(getByText('《').href).toBe('http://localhost/episodes/1');
+    expect(getByText('《').href).toBe('http://localhost/episodes');
     expect(getByText('〈').href).toBe('http://localhost/episodes/3');
     expect(getByText('2').href).toBe('http://localhost/episodes/2');
     expect(getByText('3').href).toBe('http://localhost/episodes/3');
@@ -233,7 +233,7 @@ describe('Is inclusiveFirstLast true', () => {
       />
     );
 
-    expect(getByText('《').href).toBe('http://localhost/episodes/1');
+    expect(getByText('《').href).toBe('http://localhost/episodes');
     expect(getByText('〈').href).toBe('http://localhost/episodes/3');
     expect(getByText('3').href).toBe('http://localhost/episodes/3');
     expect(getByText('4').href).toBe('http://localhost/episodes/4');
@@ -258,8 +258,8 @@ describe('Is inclusiveFirstLast true', () => {
     );
 
     expect(queryByText('《')).toBeNull();
-    expect(getByText('〈').href).toBe('http://localhost/episodes/1');
-    expect(getByText('1').href).toBe('http://localhost/episodes/1');
+    expect(getByText('〈').href).toBe('http://localhost/episodes');
+    expect(getByText('1').href).toBe('http://localhost/episodes');
     expect(getByText('2').href).toBe('http://localhost/episodes/2');
     expect(getByText('3').href).toBe('http://localhost/episodes/3');
     expect(getByText('〉').href).toBe('http://localhost/episodes/3');
@@ -281,7 +281,7 @@ describe('Is inclusiveFirstLast true', () => {
       />
     );
 
-    expect(getByText('《').href).toBe('http://localhost/episodes/1');
+    expect(getByText('《').href).toBe('http://localhost/episodes');
     expect(getByText('〈').href).toBe('http://localhost/episodes/5');
     expect(getByText('5').href).toBe('http://localhost/episodes/5');
     expect(getByText('6').href).toBe('http://localhost/episodes/6');
@@ -404,7 +404,7 @@ describe('Is firstLastSeparator true', () => {
     );
 
     expect(container.querySelectorAll('.pagination_link')).toHaveLength(4);
-    expect(getByText('〈').href).toBe('http://localhost/episodes/1');
+    expect(getByText('〈').href).toBe('http://localhost/episodes');
     expect(container.querySelectorAll('.pagination_link-first')[0].href).toBe(
       'http://localhost/episodes/2'
     );
@@ -461,7 +461,7 @@ describe('Is firstLastSeparator true', () => {
 
     expect(container.querySelectorAll('.pagination_link')).toHaveLength(3);
     expect(container.querySelectorAll('.pagination_link-first')[0].href).toBe(
-      'http://localhost/episodes/1'
+      'http://localhost/episodes'
     );
     expect(getAllByText('of')).toHaveLength(1);
     expect(container.querySelectorAll('.pagination_link-last')[0].href).toBe(

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -20,6 +20,7 @@ export function markup(rawMarkup) {
 
 // Get the previous index OR min
 export function prevIndex(i) {
+  if (i === 2) return '';
   return i > 1 ? i - 1 : 1;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5044,13 +5044,13 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^18.2:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@^18.2.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "^0.23.2"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -5062,15 +5062,20 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^18.0.0, react-is@^18.2:
+react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react@^18.2:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react-is@^18.2.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react@^18.2.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -5348,10 +5353,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
I change the `as` to `href` for the Prev button because otherwise, Talking Sense specifically breaks because the Talking Sense page 1 isn't a normal collection page, a fact which is currently unique to it. (It breaks in that, when the Prev button is clicked when you're on page 2, the URL in the bar becomes /talking-sense, but the page is a 404.) I don't really know why we're using `as` to begin with, so I can't guarantee this won't break other sites - I just tested on MPR News.