### PR TITLE
Feature/jp/94 google bot fix GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apmg/titan",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/APMG/apm-titan.git"
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "classnames": "^2.2.6",
     "next": ">=14.1.1",
-    "prop-types": "^15.7.2",
+    "prop-types": "^15.7.2 ",
     "react": "^18.2.0"
   },
   "devDependencies": {
@@ -75,14 +75,14 @@
   "files": [
     "dist"
   ],
-  "resolutions" : {
+  "resolutions": {
     "cross-spawn": ">=7.0.5",
     "@babel/traverse": ">=7.23.2",
     "ws": ">=8.17.1",
     "braces": ">=3.0.3",
     "rollup": ">=2.79.2",
-    "ajv":">=6.12.3",
-    "minimatch":  ">=3.0.5",
+    "ajv": ">=6.12.3",
+    "minimatch": ">=3.0.5",
     "path-to-regexp": "3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apmg/titan",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/APMG/apm-titan.git"
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.6",
-    "next": ">=14.1.1",
+    "next": "15.2.3",
     "prop-types": "^15.7.2 ",
     "react": "^18.2.0"
   },
@@ -56,7 +56,7 @@
     "jest-prop-type-error": "^1.1.0",
     "merge": "^2.0.0",
     "minimist": "^1.2.6",
-    "next": ">=14.1.1",
+    "next": "15.2.3",
     "path": "^0.12.7",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
@@ -83,6 +83,7 @@
     "rollup": ">=2.79.2",
     "ajv": ">=6.12.3",
     "minimatch": ">=3.0.5",
-    "path-to-regexp": "3.3.0"
+    "path-to-regexp": "3.3.0",
+    "form-data": ">=4.0.4"
   }
 }

--- a/src/atoms/Button/Button.js
+++ b/src/atoms/Button/Button.js
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import Link from '../Link/Link';
 
 const Button = ({
-  as,
   children,
   disabled,
   elementClass,
@@ -34,7 +33,6 @@ const Button = ({
       return (
         <Link
           href={href}
-          as={as}
           className={classes}
           target={newWindow ? '_blank' : null}
           rel={newWindow ? 'noopener noreferrer' : null}
@@ -59,7 +57,6 @@ const Button = ({
 };
 
 Button.propTypes = {
-  as: PropTypes.any,
   children: PropTypes.any.isRequired,
   disabled: PropTypes.bool,
   elementClass: PropTypes.string,

--- a/src/atoms/Link/Link.js
+++ b/src/atoms/Link/Link.js
@@ -10,7 +10,6 @@ import Link from 'next/link';
 const TitanLink = (props) => {
   const {
     href,
-    as,
     children,
     className,
     activeClassName,
@@ -47,6 +46,7 @@ const TitanLink = (props) => {
   }
 
   let fullClassName = className;
+
   if (activeClassName && currentPath == href) {
     fullClassName = className
       ? `${className} ${activeClassName}`
@@ -58,7 +58,6 @@ const TitanLink = (props) => {
       <Link
         {...rest}
         href={pathname(href)}
-        as={as}
         className={fullClassName}
         data-testid="hostnameLink"
       >
@@ -81,7 +80,6 @@ const TitanLink = (props) => {
       <Link
         {...rest}
         href={href}
-        as={as}
         className={fullClassName}
         data-testid="relativeLink"
       >
@@ -95,7 +93,6 @@ TitanLink.propTypes = {
   // Children are required because even if the link is styled with a class it should have text inside for accessibility
   children: PropTypes.any.isRequired,
   href: PropTypes.string.isRequired,
-  as: PropTypes.string,
   className: PropTypes.string,
   activeClassName: PropTypes.string,
   currentPath: PropTypes.string

--- a/src/atoms/Pagination/Pagination.js
+++ b/src/atoms/Pagination/Pagination.js
@@ -14,8 +14,7 @@ const Pagination = ({
   currentPage,
   totalPages,
   buffer,
-  hrefPrefix,
-  asPrefix,
+  basePath,
   hasFirstAndLast,
   inclusiveFirstLast,
   firstLastSeparator,
@@ -91,20 +90,19 @@ const Pagination = ({
     }
   };
 
-  const currentNumOrFirstNum = middleSymbol
-    ? `${asPrefix}${currentPage === 1 ? '' : `/${currentPage}`}`
-    : `${asPrefix}`;
+  const getFirstPageHref = () => {
+    if (middleSymbol) {
+      return currentPage === 1 ? `/${basePath}` : `/${basePath}/${currentPage}`;
+    }
+    return `/${basePath}`;
+  };
 
   return (
     <nav data-testid="pagination-test" className={classes}>
       <ul className="pagination_list">
         {showFirst() && (
           <li className="pagination_page pagination_page-first">
-            <Link
-              href={`/${hrefPrefix}`}
-              as={currentNumOrFirstNum}
-              className={firstLinkClasses}
-            >
+            <Link href={getFirstPageHref()} className={firstLinkClasses}>
               {firstSymbol}
             </Link>
             {firstLastSeparator && currentPage > buffer + 2 && (
@@ -118,7 +116,7 @@ const Pagination = ({
         {currentPage > 1 && (
           <li className="pagination_page pagination_page-prev">
             <Link
-              href={`/${asPrefix}/${prevIndex(currentPage)}`}
+              href={`/${basePath}/${prevIndex(currentPage)}`}
               className={prevLinkClasses}
             >
               {prevSymbol}
@@ -141,13 +139,12 @@ const Pagination = ({
               [currentNumberClass]: currentNumberClass && currentPage === value
             });
 
+            const pageHref =
+              value === 1 ? `/${basePath}` : `/${basePath}/${value}`;
+
             return (
               <li key={uuidv4()} className={pageClasses}>
-                <Link
-                  href={`/${hrefPrefix}`}
-                  as={`/${asPrefix}${value === 1 ? '' : `/${value}`}`}
-                  className={linkClasses}
-                >
+                <Link href={pageHref} className={linkClasses}>
                   {value}
                 </Link>
               </li>
@@ -156,8 +153,7 @@ const Pagination = ({
         {currentPage < totalPages && (
           <li className="pagination_page pagination_page-next">
             <Link
-              href={`/${hrefPrefix}`}
-              as={`/${asPrefix}/${nextIndex(currentPage, totalPages)}`}
+              href={`/${basePath}/${nextIndex(currentPage, totalPages)}`}
               className={nextLinkClasses}
             >
               {nextSymbol}
@@ -172,8 +168,7 @@ const Pagination = ({
               </span>
             )}
             <Link
-              href={`/${hrefPrefix}`}
-              as={`/${asPrefix}/${totalPages}`}
+              href={`/${basePath}/${totalPages}`}
               className={lastLinkClasses}
             >
               {lastSymbol}
@@ -192,8 +187,7 @@ Pagination.propTypes = {
   numberClass: PropTypes.string,
   currentNumberClass: PropTypes.string,
   currentPage: PropTypes.number.isRequired,
-  hrefPrefix: PropTypes.string.isRequired,
-  asPrefix: PropTypes.string.isRequired,
+  basePath: PropTypes.string.isRequired,
   buffer: PropTypes.number.isRequired,
   totalPages: PropTypes.number.isRequired,
   hasFirstAndLast: PropTypes.bool,

--- a/src/atoms/Pagination/__tests__/Pagination.test.js
+++ b/src/atoms/Pagination/__tests__/Pagination.test.js
@@ -9,8 +9,8 @@ const setup = () => {
   const small = {
     hasFirstAndLast: false,
     buffer: 0,
-    hrefPrefix: 'episode?slug=episodes',
-    asPrefix: 'episodes',
+    basePath: 'episodes',
+    resourceType: 'episodes',
     currentPage: data.episodesList.results.currentPage,
     totalPages: data.episodesList.results.totalPages
   };
@@ -18,8 +18,8 @@ const setup = () => {
   const medium = {
     hasFirstAndLast: false,
     buffer: 1,
-    hrefPrefix: 'episode?slug=episodes',
-    asPrefix: 'episodes',
+    basePath: 'episodes',
+    resourceType: 'episodes',
     currentPage: data.episodesList.results.currentPage,
     totalPages: data.episodesList.results.totalPages
   };
@@ -27,17 +27,13 @@ const setup = () => {
   const large = {
     hasFirstAndLast: true,
     buffer: 2,
-    hrefPrefix: 'episode?slug=episodes',
-    asPrefix: 'episodes',
+    basePath: 'episodes',
+    resourceType: 'episodes',
     currentPage: data.episodesList.results.currentPage,
     totalPages: data.episodesList.results.totalPages
   };
 
-  return {
-    small,
-    medium,
-    large
-  };
+  return { small, medium, large };
 };
 
 describe('Small Pagination', () => {
@@ -47,8 +43,7 @@ describe('Small Pagination', () => {
       <Pagination
         hasFirstAndLast={small.hasFirstAndLast}
         buffer={small.buffer}
-        hrefPrefix={small.hrefPrefix}
-        asPrefix={small.asPrefix}
+        basePath={small.basePath}
         currentPage={small.currentPage}
         resourceType={small.resourceType}
         totalPages={small.totalPages}
@@ -66,8 +61,7 @@ describe('Small Pagination', () => {
       <Pagination
         hasFirstAndLast={small.hasFirstAndLast}
         buffer={small.buffer}
-        hrefPrefix={small.hrefPrefix}
-        asPrefix={small.asPrefix}
+        basePath={small.basePath}
         resourceType={small.resourceType}
         currentPage={4}
         totalPages={small.totalPages}
@@ -88,8 +82,7 @@ describe('Medium Pagination', () => {
       <Pagination
         hasFirstAndLast={medium.hasFirstAndLast}
         buffer={medium.buffer}
-        hrefPrefix={medium.hrefPrefix}
-        asPrefix={medium.asPrefix}
+        basePath={medium.basePath}
         currentPage={medium.currentPage}
         resourceType={medium.resourceType}
         totalPages={medium.totalPages}
@@ -108,8 +101,7 @@ describe('Medium Pagination', () => {
       <Pagination
         hasFirstAndLast={medium.hasFirstAndLast}
         buffer={medium.buffer}
-        hrefPrefix={medium.hrefPrefix}
-        asPrefix={medium.asPrefix}
+        basePath={medium.basePath}
         resourceType={medium.resourceType}
         currentPage={4}
         totalPages={medium.totalPages}
@@ -132,8 +124,7 @@ describe('Large Pagination', () => {
       <Pagination
         hasFirstAndLast={large.hasFirstAndLast}
         buffer={large.buffer}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         currentPage={large.currentPage}
         resourceType={large.resourceType}
         totalPages={large.totalPages}
@@ -154,8 +145,7 @@ describe('Large Pagination', () => {
       <Pagination
         hasFirstAndLast={large.hasFirstAndLast}
         buffer={large.buffer}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={4}
         totalPages={large.totalPages}
@@ -180,8 +170,7 @@ describe('Large Pagination', () => {
       <Pagination
         hasFirstAndLast={large.hasFirstAndLast}
         buffer={large.buffer}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={4}
         totalPages={large.totalPages}
@@ -203,8 +192,7 @@ describe('Large Pagination', () => {
       <Pagination
         elementClass="foo"
         buffer={large.buffer}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={4}
         totalPages={large.totalPages}
@@ -224,8 +212,7 @@ describe('Is inclusiveFirstLast true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={4}
         totalPages={7}
@@ -248,8 +235,7 @@ describe('Is inclusiveFirstLast true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={2}
         totalPages={7}
@@ -272,8 +258,7 @@ describe('Is inclusiveFirstLast true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={6}
         totalPages={7}
@@ -298,8 +283,7 @@ describe('Is firstLastSeparator true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={5}
         totalPages={9}
@@ -317,8 +301,7 @@ describe('Is firstLastSeparator true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={3}
         totalPages={9}
@@ -336,8 +319,7 @@ describe('Is firstLastSeparator true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={8}
         totalPages={9}
@@ -355,8 +337,7 @@ describe('Is firstLastSeparator true', () => {
       <Pagination
         hasFirstAndLast={true}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={8}
         totalPages={9}
@@ -375,8 +356,7 @@ describe('Is firstLastSeparator true', () => {
         hasFirstAndLast={true}
         inclusiveFirstLast={false}
         buffer={1}
-        hrefPrefix={large.hrefPrefix}
-        asPrefix={large.asPrefix}
+        basePath={large.basePath}
         resourceType={large.resourceType}
         currentPage={8}
         totalPages={9}
@@ -394,8 +374,7 @@ describe('Is firstLastSeparator true', () => {
         hasFirstAndLast={true}
         inclusiveFirstLast={false}
         buffer={1}
-        hrefPrefix={medium.hrefPrefix}
-        asPrefix={medium.asPrefix}
+        basePath={medium.basePath}
         resourceType={medium.resourceType}
         currentPage={2}
         totalPages={8}
@@ -422,8 +401,7 @@ describe('Is firstLastSeparator true', () => {
         hasFirstAndLast={true}
         inclusiveFirstLast={false}
         buffer={1}
-        hrefPrefix={medium.hrefPrefix}
-        asPrefix={medium.asPrefix}
+        basePath={medium.basePath}
         resourceType={medium.resourceType}
         currentPage={4}
         totalPages={7}
@@ -450,8 +428,7 @@ describe('Is firstLastSeparator true', () => {
         hasFirstAndLast={true}
         inclusiveFirstLast={false}
         buffer={1}
-        hrefPrefix={medium.hrefPrefix}
-        asPrefix={medium.asPrefix}
+        basePath={medium.basePath}
         resourceType={medium.resourceType}
         currentPage={1}
         totalPages={2}
@@ -477,8 +454,7 @@ describe('Is firstLastSeparator true', () => {
         hasFirstAndLast={true}
         inclusiveFirstLast={false}
         buffer={1}
-        hrefPrefix={medium.hrefPrefix}
-        asPrefix={medium.asPrefix}
+        basePath={medium.basePath}
         resourceType={medium.resourceType}
         currentPage={8}
         totalPages={8}

--- a/src/molecules/Teaser/Teaser.js
+++ b/src/molecules/Teaser/Teaser.js
@@ -14,7 +14,6 @@ const Teaser = ({
   headingLevel,
   publishDate,
   href,
-  as,
   tag,
   audioPlayButton,
   image,
@@ -43,35 +42,37 @@ const Teaser = ({
         <div className="teaser_button">{audioPlayButton}</div>
       )}
 
-      <Link href={href} as={as} className="teaser_link">
-        {video ? (
-          <Video video={video} hideCaption={hideVideoCaption} />
-        ) : (
-          <div className="teaser_image">{image}</div>
-        )}
-        <div className="teaser_content">
-          <div className="teaser_header">
-            <Heading level={headingLevel}>{title}</Heading>
-          </div>
-
-          {(publishDate || contributors) && (
-            <div className="teaser_meta">
-              {publishDate && (
-                <div className="teaser_pubdate">{publishDate}</div>
-              )}
-
-              {contributors && (
-                <div className="teaser_contributors">
-                  {`By ${toSentence(contributors)}`}
-                </div>
-              )}
-            </div>
+      <Link href={href} className="teaser_link">
+        <div className="teaser_link">
+          {video ? (
+            <Video video={video} hideCaption={hideVideoCaption} />
+          ) : (
+            <div className="teaser_image">{image}</div>
           )}
+          <div className="teaser_content">
+            <div className="teaser_header">
+              <Heading level={headingLevel}>{title}</Heading>
+            </div>
+
+            {(publishDate || contributors) && (
+              <div className="teaser_meta">
+                {publishDate && (
+                  <div className="teaser_pubdate">{publishDate}</div>
+                )}
+
+                {contributors && (
+                  <div className="teaser_contributors">
+                    {`By ${toSentence(contributors)}`}
+                  </div>
+                )}
+              </div>
+            )}
+            {description && (
+              <div className="teaser_body userContent">{description}</div>
+            )}
+          </div>
         </div>
       </Link>
-      {description && (
-        <div className="teaser_body userContent">{description}</div>
-      )}
     </article>
   );
 };
@@ -83,7 +84,6 @@ Teaser.propTypes = {
   elementClass: PropTypes.string,
   headingLevel: PropTypes.number.isRequired,
   href: PropTypes.string.isRequired,
-  as: PropTypes.string,
   image: PropTypes.object,
   video: PropTypes.object,
   publishDate: PropTypes.node,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,50 +1345,50 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@next/env@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.1.6.tgz#2fa863d8c568a56b1c8328a86e621b8bdd4f2a20"
-  integrity sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==
+"@next/env@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/env/-/env-15.2.3.tgz#037ee37c4d61fcbdbb212694cc33d7dcf6c7975a"
+  integrity sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==
 
-"@next/swc-darwin-arm64@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.6.tgz#92f99badab6cb41f4c5c11a3feffa574bd6a9276"
-  integrity sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==
+"@next/swc-darwin-arm64@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz#2688c185651ef7a16e5642c85048cc4e151159fa"
+  integrity sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==
 
-"@next/swc-darwin-x64@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.6.tgz#f56f4f8d5f6cb5d3915912ac95590d387f897da5"
-  integrity sha512-x1jGpbHbZoZ69nRuogGL2MYPLqohlhnT9OCU6E6QFewwup+z+M6r8oU47BTeJcWsF2sdBahp5cKiAcDbwwK/lg==
+"@next/swc-darwin-x64@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz#3e802259b2c9a4e2ad55ff827f41f775b726fc7d"
+  integrity sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==
 
-"@next/swc-linux-arm64-gnu@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.6.tgz#0aaffae519c93d1006419d7b98c34ebfd80ecacd"
-  integrity sha512-jar9sFw0XewXsBzPf9runGzoivajeWJUc/JkfbLTC4it9EhU8v7tCRLH7l5Y1ReTMN6zKJO0kKAGqDk8YSO2bg==
+"@next/swc-linux-arm64-gnu@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz#315d7b54b89153f125bdc3e40bcb7ccf94ef124b"
+  integrity sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==
 
-"@next/swc-linux-arm64-musl@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.6.tgz#e7398d3d31ca60033f708a718cd6c31edcee2e9a"
-  integrity sha512-+n3u//bfsrIaZch4cgOJ3tXCTbSxz0s6brJtU3SzLOvkJlPQMJ+eHVRi6qM2kKKKLuMY+tcau8XD9CJ1OjeSQQ==
+"@next/swc-linux-arm64-musl@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz#a1a458eb7cf19c59d2014ee388a7305e9a77973f"
+  integrity sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==
 
-"@next/swc-linux-x64-gnu@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.6.tgz#d76c72508f4d79d6016cab0c52640b93e590cffb"
-  integrity sha512-SpuDEXixM3PycniL4iVCLyUyvcl6Lt0mtv3am08sucskpG0tYkW1KlRhTgj4LI5ehyxriVVcfdoxuuP8csi3kQ==
+"@next/swc-linux-x64-gnu@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.3.tgz#a3cf22eda7601536ccd68e8ba4c1bfb4a1a33460"
+  integrity sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==
 
-"@next/swc-linux-x64-musl@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.6.tgz#0b8ba80a53e65bf8970ed11ea923001e2512c7cb"
-  integrity sha512-L4druWmdFSZIIRhF+G60API5sFB7suTbDRhYWSjiw0RbE+15igQvE2g2+S973pMGvwN3guw7cJUjA/TmbPWTHQ==
+"@next/swc-linux-x64-musl@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.3.tgz#0e33c1224c76aa3078cc2249c80ef583f9d7a943"
+  integrity sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==
 
-"@next/swc-win32-arm64-msvc@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.6.tgz#81b5dbbfdada2c05deef688e799af4a24097b65f"
-  integrity sha512-s8w6EeqNmi6gdvM19tqKKWbCyOBvXFbndkGHl+c9YrzsLARRdCHsD9S1fMj8gsXm9v8vhC8s3N8rjuC/XrtkEg==
+"@next/swc-win32-arm64-msvc@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz#4e0583fb981b931915a9ad22e579f9c9d5b803dd"
+  integrity sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==
 
-"@next/swc-win32-x64-msvc@15.1.6":
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.6.tgz#131993c45ffd124fb4b15258e2f3f9669c143e3c"
-  integrity sha512-6xomMuu54FAFxttYr5PJbEfu96godcxBTRk1OhAvJq0/EnmFU/Ybiax30Snis4vdWZ9LGpf7Roy5fSs7v/5ROQ==
+"@next/swc-win32-x64-msvc@15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz#727b90c7dcc2279344115a94b99d93d452956f02"
+  integrity sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==
 
 "@parcel/watcher-android-arm64@2.5.1":
   version "2.5.1"
@@ -3471,13 +3471,15 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.2.7"
 
-form-data@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
-  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
+form-data@>=4.0.4, form-data@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
@@ -4934,12 +4936,12 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-next@>=14.1.1:
-  version "15.1.6"
-  resolved "https://registry.yarnpkg.com/next/-/next-15.1.6.tgz#ce22fd0a8f36da1fc4aba86e3ec7e98eb248c555"
-  integrity sha512-Hch4wzbaX0vKQtalpXvUiw5sYivBy4cm5rzUKrBnUB/y436LGrvOUqYvlSeNVCWFO/770gDlltR9gqZH62ct4Q==
+next@15.2.3:
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/next/-/next-15.2.3.tgz#1ac803c08076d47eb5b431cb625135616c6bec7e"
+  integrity sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==
   dependencies:
-    "@next/env" "15.1.6"
+    "@next/env" "15.2.3"
     "@swc/counter" "0.1.3"
     "@swc/helpers" "0.5.15"
     busboy "1.6.0"
@@ -4947,14 +4949,14 @@ next@>=14.1.1:
     postcss "8.4.31"
     styled-jsx "5.1.6"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "15.1.6"
-    "@next/swc-darwin-x64" "15.1.6"
-    "@next/swc-linux-arm64-gnu" "15.1.6"
-    "@next/swc-linux-arm64-musl" "15.1.6"
-    "@next/swc-linux-x64-gnu" "15.1.6"
-    "@next/swc-linux-x64-musl" "15.1.6"
-    "@next/swc-win32-arm64-msvc" "15.1.6"
-    "@next/swc-win32-x64-msvc" "15.1.6"
+    "@next/swc-darwin-arm64" "15.2.3"
+    "@next/swc-darwin-x64" "15.2.3"
+    "@next/swc-linux-arm64-gnu" "15.2.3"
+    "@next/swc-linux-arm64-musl" "15.2.3"
+    "@next/swc-linux-x64-gnu" "15.2.3"
+    "@next/swc-linux-x64-musl" "15.2.3"
+    "@next/swc-win32-arm64-msvc" "15.2.3"
+    "@next/swc-win32-x64-msvc" "15.2.3"
     sharp "^0.33.5"
 
 node-addon-api@^7.0.0:


### PR DESCRIPTION
Remove legacy method of using `<Link/>` in Next 12 although we were on Next 14. 

I cleaned up pagination to make it easier to understand with `baseUrl` which combines "href" and "as", a feature to link in next 14+.

I also had to upgrade Next due to Critical Audit warning: "Authorization Bypass in Next.js Middleware" and was patched in Next 15.2.3.  https://www.npmjs.com/advisories/1106691      
